### PR TITLE
feature: embed, social share blocks

### DIFF
--- a/blocks/embed/embed-facebook.js
+++ b/blocks/embed/embed-facebook.js
@@ -1,0 +1,9 @@
+import { loadScript } from '../../scripts/scripts.js';
+
+export default function embedMarkup(url) {
+  const embedHTML = `<div class="fb-page" data-href="${url}" data-width="380" data-hide-cover="false" data-show-facepile="false">
+    <blockquote cite="${url}" class="fb-xfbml-parse-ignore"><a href="${url}">${url}</a></blockquote>
+  </div>`;
+  loadScript('https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v15.0');
+  return embedHTML;
+}

--- a/blocks/embed/embed-instagram.js
+++ b/blocks/embed/embed-instagram.js
@@ -1,0 +1,46 @@
+import { loadScript } from '../../scripts/scripts.js';
+
+export default function embedMarkup(url) {
+  const embedHTML = `<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="${url}" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
+  <div style="padding:16px;"><a href="${url}" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank">
+    <div style=" display: flex; flex-direction: row; align-items: center;">
+      <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div>
+      <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;">
+        <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div>
+        <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div>
+      </div>
+    </div>
+    <div style="padding: 19% 0;"></div>
+    <div style="display:block; height:50px; margin:0 auto 12px; width:50px;">
+      <span class="icon icon-instagram"></span>
+    </div>
+    <div style="padding-top: 8px;">
+      <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;">View this post on Instagram</div>
+    </div>
+    <div style="padding: 12.5% 0;"></div>
+    <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;">
+      <div>
+        <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div>
+        <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div>
+        <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div>
+      </div>
+      <div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div>
+      <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div>
+    </div>
+    <div style="margin-left: auto;">
+      <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div>
+      <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div>
+      <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div>
+    </div>
+  </div>
+  <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;">
+    <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div>
+    <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div>
+  </div></a>
+  <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">
+    <a href="${url}" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A post shared by Supernatural Impala</a>
+  </p>
+  </div></blockquote>`;
+  loadScript('https://www.instagram.com/embed.js');
+  return embedHTML;
+}

--- a/blocks/embed/embed-youtube-channel.js
+++ b/blocks/embed/embed-youtube-channel.js
@@ -1,0 +1,7 @@
+import { loadScript } from '../../scripts/scripts.js';
+
+export default function embedMarkup(url) {
+  const embedHTML = `<div class="g-ytsubscribe" data-channel="edergmbh" data-href="${url}" data-tabs="timeline" data-height="100" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="true"data-layout="full" data-count="default"></div>`;
+  loadScript('https://apis.google.com/js/platform.js');
+  return embedHTML;
+}

--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,0 +1,80 @@
+main .embed {
+  width: unset;
+  text-align: center;
+  max-width: 800px;
+}
+
+main .embed > div {
+  display: flex;
+  justify-content: center;
+}
+
+main .embed figure.video {
+  margin: 0;
+}
+
+main .embed video.video-embed-item {
+  max-width: 800px;
+}
+
+main .embed.embed-facebook {
+  margin-top: 25px;
+}
+
+main .embed.embed-facebook > div {
+  justify-content: left;
+}
+
+main .embed.embed-youtube-com-user > div {
+  display: flex !important;
+  justify-content: left;
+}
+
+main .embed .embed-placeholder {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  position: relative;
+}
+
+main .embed .embed-placeholder > * {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+main .embed .embed-placeholder picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+main .embed .embed-placeholder-play button {
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  transform: scale(3);
+  width: 22px;
+  height: 22px;
+  border: 2px solid;
+  border-radius: 20px;
+  padding: 0;
+}
+
+main .embed .embed-placeholder-play button::before {
+  content: '';
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  width: 0;
+  height: 10px;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 6px solid;
+  top: 4px;
+  left: 7px;
+}

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -1,0 +1,142 @@
+// eslint-disable-next-line import/no-duplicates
+import { toClassName } from '../../scripts/lib-franklin.js';
+// eslint-disable-next-line import/no-duplicates
+import { decorateIcons } from '../../scripts/lib-franklin.js';
+
+const getDefaultEmbed = (
+  url,
+) => `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+    <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen=""
+      scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+    </iframe>
+  </div>`;
+
+const embedYumpu = (
+  url,
+) => `<div class="embed-container" id="ypembedcontainer" style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+  <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen=""
+    scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+  </iframe>
+</div>`;
+
+const embedYoutube = (url, autoplay) => {
+  const usp = new URLSearchParams(url.search);
+  const suffix = autoplay ? '&muted=1&autoplay=1' : '';
+  let vid = usp.get('v') && encodeURIComponent(usp.get('v'));
+  const embed = url.pathname;
+  if (url.origin.includes('youtu.be')) {
+    [, vid] = url.pathname.split('/');
+  }
+  const embedHTML = `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+      <iframe src="https://www.youtube.com${vid ? `/embed/${vid}?rel=0&v=${vid}${suffix}` : embed}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" 
+      allow="autoplay; fullscreen; picture-in-picture; encrypted-media; accelerometer; gyroscope; picture-in-picture" allowfullscreen="" scrolling="no" title="Content from Youtube" loading="lazy"></iframe>
+    </div>`;
+  return embedHTML;
+};
+
+const embedYoutubeChannel = async (url) => {
+  // offload the Youtube Channel embed as this is only used on the social media page
+  const mod = await import('./embed-youtube-channel.js');
+  let embedHTML = '';
+  if (mod.default) {
+    embedHTML = await mod.default(url);
+  }
+  return embedHTML;
+};
+
+const embedInstagram = async (url) => {
+  // offload the instagram template to only load the large template if really needed
+  const mod = await import('./embed-instagram.js');
+  let embedHTML = '';
+  if (mod.default) {
+    embedHTML = await mod.default(url);
+  }
+  return embedHTML;
+};
+
+const embedFacebook = async (url) => {
+  // offload the Facebook Page template as this is only used on the social media page
+  const mod = await import('./embed-facebook.js');
+  let embedHTML = '';
+  if (mod.default) {
+    embedHTML = await mod.default(url);
+  }
+  return embedHTML;
+};
+
+const embedVideo = (url) => `
+  <figure class="video"><div class="video-embed">
+  <video  controls="" autoplay="" class="video-embed-item"><source src="${url}" type="video/mp4"></video>
+  </div></figure>`;
+
+const loadEmbed = async (block, link, autoplay) => {
+  if (block.classList.contains('embed-is-loaded')) {
+    return;
+  }
+
+  const EMBEDS_CONFIG = [
+    {
+      match: ['youtube.com/user/', 'youtube.com/channel/'],
+      embed: embedYoutubeChannel,
+    },
+    {
+      match: ['youtube', 'youtu.be'],
+      embed: embedYoutube,
+    },
+    {
+      match: ['yumpu'],
+      embed: embedYumpu,
+    },
+    {
+      match: ['instagram'],
+      embed: embedInstagram,
+    },
+    {
+      match: ['facebook'],
+      embed: embedFacebook,
+    },
+    {
+      match: ['.mp4'],
+      embed: embedVideo,
+    },
+  ];
+
+  const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
+  const url = new URL(link);
+  if (config) {
+    const className = toClassName(config.match[0]);
+    block.innerHTML = await config.embed(url, autoplay);
+    block.classList = `block embed embed-${className}`;
+    decorateIcons(block);
+  } else {
+    block.innerHTML = getDefaultEmbed(url);
+    block.classList = 'block embed';
+  }
+
+  block.classList.add('embed-is-loaded');
+};
+
+export default function decorate(block) {
+  const placeholder = block.querySelector('picture');
+  const link = block.querySelector('a').href;
+  block.textContent = '';
+
+  if (placeholder) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'embed-placeholder';
+    wrapper.innerHTML = '<div class="embed-placeholder-play"><button title="Play"></button></div>';
+    wrapper.prepend(placeholder);
+    wrapper.addEventListener('click', () => {
+      loadEmbed(block, link, true);
+    });
+    block.append(wrapper);
+  } else {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        observer.disconnect();
+        loadEmbed(block, link);
+      }
+    });
+    observer.observe(block);
+  }
+}

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -1,0 +1,1 @@
+/* nothing here */

--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -1,0 +1,45 @@
+/*
+ * Fragment Block
+ * Include content from one Helix page in another.
+ * https://www.hlx.live/developer/block-collection/fragment
+ */
+
+import {
+  decorateMain,
+} from '../../scripts/scripts.js';
+
+import {
+  loadBlocks,
+} from '../../scripts/lib-franklin.js';
+
+/**
+ * Loads a fragment.
+ * @param {string} path The path to the fragment
+ * @returns {HTMLElement} The root element of the fragment
+ */
+async function loadFragment(path) {
+  if (path && path.startsWith('/')) {
+    const resp = await fetch(`${path}.plain.html`);
+    if (resp.ok) {
+      const main = document.createElement('main');
+      main.innerHTML = await resp.text();
+      decorateMain(main);
+      await loadBlocks(main);
+      return main;
+    }
+  }
+  return null;
+}
+
+export default async function decorate(block) {
+  const link = block.querySelector('a');
+  const path = link ? link.getAttribute('href') : block.textContent.trim();
+  const fragment = await loadFragment(path);
+  if (fragment) {
+    const fragmentSection = fragment.querySelector(':scope .section');
+    if (fragmentSection) {
+      block.closest('.section').classList.add(...fragmentSection.classList);
+      block.closest('.fragment-wrapper').replaceWith(...fragmentSection.childNodes);
+    }
+  }
+}

--- a/blocks/social-share/social-share.css
+++ b/blocks/social-share/social-share.css
@@ -1,0 +1,34 @@
+.blog .share-event {
+  text-align: left;
+  padding: 15px 0 45px;
+  border-top: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  max-width: 60%;
+  margin: 150px auto auto;
+}
+
+.blog .share-event p {
+  margin: 0 0 15px;
+  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 14px;
+  display: none;
+}
+
+.blog .social-links ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+.blog .social-links li {
+  float: left;
+  padding-right: 30px;
+}
+
+.blog .social-links .icon {
+  height: 16px;
+  width: 16px;
+}
+

--- a/blocks/social-share/social-share.js
+++ b/blocks/social-share/social-share.js
@@ -1,0 +1,110 @@
+import { getMetadata } from '../../scripts/lib-franklin.js';
+// eslint-disable-next-line object-curly-newline
+import { a, div, img, li, p, ul } from '../../scripts/dom-helpers.js';
+
+function getURL() {
+  return encodeURIComponent(window.location.href);
+}
+
+function getTitle() {
+  const h1 = document.querySelector('h1');
+  return h1 ? encodeURIComponent(h1.textContent) : '';
+}
+
+function onSocialShareClick(event) {
+  event.preventDefault();
+  const href = event.currentTarget.getAttribute('href');
+  if (!href) return;
+  window.open(href, 'popup', 'width=800,height=700,scrollbars=no,resizable=no');
+}
+
+function decorateLink(social, type, icon, url) {
+  icon.setAttribute('aria-label', type);
+  if (!url) return;
+
+  social.append(
+    a(
+      {
+        href: url,
+        'aria-label': `Share to ${type}`,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        onclick: onSocialShareClick,
+      },
+      icon,
+    ),
+  );
+}
+
+export function decorateIcons(element) {
+  const url = getURL();
+  const title = getTitle();
+
+  element.querySelectorAll('li')
+    .forEach((social) => {
+      const type = social.getAttribute('data-type');
+      const icon = social.querySelector('img');
+
+      switch (type) {
+        case 'facebook':
+          decorateLink(social, 'Facebook', icon, `https://www.facebook.com/sharer/sharer.php?u=${url}`);
+          break;
+        case 'linkedin':
+          decorateLink(social, 'LinkedIn', icon, `https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}`);
+          break;
+        case 'twitter':
+          decorateLink(social, 'Twitter', icon, `https://www.twitter.com/share?&url=${url}&text=${title}`);
+          break;
+          /* This is just a link.
+        case 'youtube-play':
+          decorateLink(social, 'Youtube', icon, 'https://www.youtube.com/user/[channelnamehere]');
+          break;
+           */
+        default:
+          break;
+      }
+    });
+}
+
+// using domhelpers
+export function socialShareBlock(title, socials) {
+  return div(
+    { class: 'share-event' },
+    p(title),
+    div(
+      { class: 'social-links' },
+      ul(
+        { class: 'button-container' },
+        ...socials.map((social) =>
+          // eslint-disable-next-line implicit-arrow-linebreak
+          li(
+            {
+              class: `share-${social}`,
+              'data-type': social,
+            },
+            img({ class: `icon icon-${social}`, src: `../icons/${social}.svg` }),
+          )),
+      ),
+    ),
+  );
+}
+
+export default function decorate(block) {
+  const template = getMetadata('template')
+    .toLowerCase();
+
+  let title = '';
+  if (block.querySelector('.social-share p')) {
+    title = block.querySelector('.social-share p').innerHTML;
+  }
+
+  const socials = template === 'blog'
+    ? ['linkedin', 'facebook', 'twitter']
+    : ['facebook', 'linkedin', 'twitter'];
+
+  block.innerHTML = '';
+  // block.appendChild(socialShareBlock(title, socials));
+  block.appendChild(socialShareBlock(title, socials));
+
+  decorateIcons(block);
+}

--- a/scripts/dom-helpers.js
+++ b/scripts/dom-helpers.js
@@ -1,0 +1,166 @@
+/* eslint-disable no-param-reassign */
+
+/** script stolen from github.com/hlxsites/moleculardevices
+ * Example Usage:
+ *
+ * domEl('main',
+ *  div({ class: 'card' },
+ *  a({ href: item.path },
+ *    div({ class: 'card-thumb' },
+ *     createOptimizedPicture(item.image, item.title, 'lazy', [{ width: '800' }]),
+ *    ),
+ *   div({ class: 'card-caption' },
+ *      h3(item.title),
+ *      p({ class: 'card-description' }, item.description),
+ *      p({ class: 'button-container' },
+ *       a({ href: item.path, 'aria-label': 'Read More', class: 'button primary' }, 'Read More'),
+ *     ),
+ *   ),
+ *  ),
+ * )
+ */
+
+/**
+ * Helper for more concisely generating DOM Elements with attributes and children
+ * @param {string} tag HTML tag of the desired element
+ * @param  {[Object?, ...Element]} items: First item can optionally be an object of attributes,
+ *  everything else is a child element
+ * @returns {Element} The constructred DOM Element
+ */
+export function domEl(tag, ...items) {
+  const element = document.createElement(tag);
+
+  if (!items || items.length === 0) return element;
+
+  if (!(items[0] instanceof Element || items[0] instanceof HTMLElement) && typeof items[0] === 'object') {
+    const [attributes, ...rest] = items;
+    items = rest;
+
+    Object.entries(attributes)
+      .forEach(([key, value]) => {
+        if (!key.startsWith('on')) {
+          element.setAttribute(key, Array.isArray(value) ? value.join(' ') : value);
+        } else {
+          element.addEventListener(key.substring(2)
+            .toLowerCase(), value);
+        }
+      });
+  }
+
+  items.forEach((item) => {
+    item = item instanceof Element || item instanceof HTMLElement
+      ? item
+      : document.createTextNode(item);
+    element.appendChild(item);
+  });
+
+  return element;
+}
+
+/*
+  More short hand functions can be added for very common DOM elements below.
+  domEl function from above can be used for one off DOM element occurrences.
+*/
+export function div(...items) {
+  return domEl('div', ...items);
+}
+
+export function p(...items) {
+  return domEl('p', ...items);
+}
+
+export function a(...items) {
+  return domEl('a', ...items);
+}
+
+export function h1(...items) {
+  return domEl('h1', ...items);
+}
+
+export function h2(...items) {
+  return domEl('h2', ...items);
+}
+
+export function h3(...items) {
+  return domEl('h3', ...items);
+}
+
+export function h4(...items) {
+  return domEl('h4', ...items);
+}
+
+export function h5(...items) {
+  return domEl('h5', ...items);
+}
+
+export function h6(...items) {
+  return domEl('h6', ...items);
+}
+
+export function ul(...items) {
+  return domEl('ul', ...items);
+}
+
+export function ol(...items) {
+  return domEl('ol', ...items);
+}
+
+export function li(...items) {
+  return domEl('li', ...items);
+}
+
+export function i(...items) {
+  return domEl('i', ...items);
+}
+
+export function img(...items) {
+  return domEl('img', ...items);
+}
+
+export function span(...items) {
+  return domEl('span', ...items);
+}
+
+export function form(...items) {
+  return domEl('form', ...items);
+}
+
+export function input(...items) {
+  return domEl('input', ...items);
+}
+
+export function label(...items) {
+  return domEl('label', ...items);
+}
+
+export function button(...items) {
+  return domEl('button', ...items);
+}
+
+export function iframe(...items) {
+  return domEl('iframe', ...items);
+}
+
+export function nav(...items) {
+  return domEl('nav', ...items);
+}
+
+export function fieldset(...items) {
+  return domEl('fieldset', ...items);
+}
+
+export function article(...items) {
+  return domEl('article', ...items);
+}
+
+export function strong(...items) {
+  return domEl('strong', ...items);
+}
+
+export function select(...items) {
+  return domEl('select', ...items);
+}
+
+export function option(...items) {
+  return domEl('option', ...items);
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -31,12 +31,31 @@ function buildHeroBlock(main) {
   }
 }
 
+// used to add 3rd party embed js files to the head
+// TODO: keep an eye on lighthouse scores for this
+export function loadScript(url, callback, type, async) {
+  const head = document.querySelector('head');
+  const script = document.createElement('script');
+  script.src = url;
+  if (async) {
+    script.async = true;
+  }
+  if (type) {
+    script.setAttribute('type', type);
+  }
+  script.onload = callback;
+  head.append(script);
+  return script;
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
  */
 
 function buildAutoBlocks(main) {
+  const container = document.querySelector('main div');
+  container.append(buildBlock('social-share', '<p>Share this blog post</p>'));
   try {
     buildHeroBlock(main);
   } catch (error) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -58,7 +58,11 @@ function buildAutoblogBlock(main) {
     const section = document.createElement('div');
     const elems = [authorcontent, publishedcontent, readcontent];
     const subsection1 = document.createElement('div');
-    elems.forEach((x) => { const col = document.createElement('div'); col.textContent = x; subsection1.appendChild(col); });
+    elems.forEach((x) => {
+      const col = document.createElement('div');
+      col.textContent = x;
+      subsection1.appendChild(col);
+    });
     section.appendChild(subsection1);
     subsection1.after(h1);
     // const updatedcontent = getMetadata('updated');
@@ -71,6 +75,7 @@ function buildAutoblogBlock(main) {
     section.classList.add('autoblog');
     section.classList.add('block');
   }
+}
 
 /**
  * Builds all synthetic blocks in a container element.


### PR DESCRIPTION
Contains new embed block and share block. Share block was adapted from another repo that used some DOMhelper JS, so this was added as well.

Fix #4 

Test URLs:
- Before: https://main--impala--mkclawson.hlx.page/blog/bringin-back-baby
- After: https://4-embedblock--impala--mkclawson.hlx.page/blog/bringin-back-baby

New branch should be showing sharing social icons under the blog post which, when clicked, bring up modals prompting the user to log in and share.

Missing is "link copy" which I will create a new ticket for.
